### PR TITLE
Update README.md to specify Beta version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Want more features? Vote for this [SignalRGB feature request](https://forum.sign
 - SignalRGB software installed and running on a Windows PC on your network
 - SignalRGB HTTP API enabled (default port: 16038)
 - SignalRGB [Pro subscription](https://signalrgb.com/pricing/) (required for API)
+- SignalRGB 2.3.108-BETA or newer is required
 
 ## 🛠️ Installation
 


### PR DESCRIPTION
Add requirement for SignalRGB 2.3.108-beta or newer following new API release.