### PR TITLE
Entity id slugify

### DIFF
--- a/custom_components/signalrgb/button.py
+++ b/custom_components/signalrgb/button.py
@@ -14,6 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import slugify
 
 from signalrgb import AsyncSignalRGBClient, SignalRGBException
 
@@ -111,7 +112,7 @@ class SignalRGBButton(ButtonEntity):
             manufacturer=MANUFACTURER,
             model=MODEL,
         )
-        self.entity_id = f"button.signalrgb_{description.key}_{config_entry.entry_id}"
+        self.entity_id = f"button.signalrgb_{slugify(description.key)}_{slugify(config_entry.entry_id)}"
         LOGGER.debug("SignalRGBButton initialized: %s", self.entity_id)
 
     async def async_press(self) -> None:

--- a/custom_components/signalrgb/light.py
+++ b/custom_components/signalrgb/light.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
+from homeassistant.util import slugify
 
 from signalrgb import AsyncSignalRGBClient, SignalRGBException
 from signalrgb.model import Effect
@@ -112,7 +113,7 @@ class SignalRGBLight(CoordinatorEntity, LightEntity):
             model=MODEL,
         )
         self._effect_list: list[str] = []
-        self.entity_id = f"light.signalrgb_{config_entry.entry_id}"
+        self.entity_id = f"light.signalrgb_{slugify(config_entry.entry_id)}"
         self._current_effect: Effect | None = None
         self._is_on: bool = False
         self._brightness: int = 0  # This is now 0-100

--- a/custom_components/signalrgb/manifest.json
+++ b/custom_components/signalrgb/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
     "signalrgb>=1.0.1"
   ],
-  "version": "1.0.1"
+  "version": "1.0.2-fix-entity-id"
 }

--- a/custom_components/signalrgb/select.py
+++ b/custom_components/signalrgb/select.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
+from homeassistant.util import slugify
 
 from signalrgb import AsyncSignalRGBClient, SignalRGBException
 from signalrgb.model import Effect, Layout
@@ -193,7 +194,7 @@ class SignalRGBBaseSelect(CoordinatorEntity, SelectEntity):
             manufacturer=MANUFACTURER,
             model=MODEL,
         )
-        self.entity_id = f"select.signalrgb_{select_type}_{config_entry.entry_id}"
+        self.entity_id = f"select.signalrgb_{slugify(select_type)}_{slugify(config_entry.entry_id)}"
         LOGGER.debug(
             "SignalRGB%sSelect initialized: %s", select_type.title(), self.entity_id
         )


### PR DESCRIPTION
Fixes #13, 2026.2 appears to be more picky about entity IDs. This PR slugifies string variables before being used to generate an entity ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed entity identifier generation for button, light, and select components to properly normalize special characters, ensuring stable device naming and improved compatibility with Home Assistant automations and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->