### PR TITLE
fix(config_flow): close test client on every error path

### DIFF
--- a/custom_components/signalrgb/config_flow.py
+++ b/custom_components/signalrgb/config_flow.py
@@ -37,6 +37,7 @@ class SignalRGBConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA, errors=errors)
 
+        client = None
         try:
             # Initialize client in a thread executor to avoid blocking SSL certificate loading
             client = await self.hass.async_add_executor_job(
@@ -50,7 +51,6 @@ class SignalRGBConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             # Test the connection by getting the current effect
             await client.get_current_effect()
-            await client.aclose()
             LOGGER.debug("Successfully connected to SignalRGB")
         except SignalRGBConnectionError:
             LOGGER.error(
@@ -69,6 +69,12 @@ class SignalRGBConfigFlow(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}")
             self._abort_if_unique_id_configured()
             return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
+        finally:
+            if client is not None:
+                try:
+                    await client.aclose()
+                except Exception:  # pylint: disable=broad-except # noqa: BLE001
+                    pass
 
         return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA, errors=errors)
 


### PR DESCRIPTION
## Summary

`async_step_user` calls `await client.aclose()` only on the success branch. Every connect / auth / unexpected-error path returns without closing, leaking the underlying httpx session.

Wraps the test in `try/finally` so the client is closed on every exit path. Swallows aclose errors silently to avoid masking the original error in the surfaced `errors["base"]`.

## Backwards compat

No behavior change on the success path; only error paths now also clean up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SignalRGB configuration reliability by ensuring proper resource cleanup in all scenarios, preventing potential connection issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/signalrgb-homeassistant/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->